### PR TITLE
feat: windows support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use zed::settings::LspSettings;
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
 const NPM_PKG_NAME: &str = "cspell-lsp";
-const LS_BIN_PATH: &str = "node_modules/.bin/cspell-lsp";
+const LS_BIN_PATH: &str = "node_modules/cspell-lsp/dist/bundle.mjs";
 
 #[derive(Default)]
 struct CSpellExtension {
@@ -72,8 +72,7 @@ impl zed::Extension for CSpellExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -99,3 +98,25 @@ impl zed::Extension for CSpellExtension {
 }
 
 zed::register_extension!(CSpellExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
Replaces the .bin/cspell-lsp path with the bundle directly, the scripts don't seem to run properly for me on windows.

Adds the "sanitize_windows_path" function which fixes the bug on windows that causes weird broken paths and failing to start on windows.

Closes #7 