### PR TITLE
Update cspell LSP package and configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ use std::{env, fs};
 use zed::settings::LspSettings;
 use zed_extension_api::{self as zed, LanguageServerId, Result};
 
-const NPM_PKG_NAME: &str = "cspell-lsp";
-const LS_BIN_PATH: &str = "node_modules/cspell-lsp/dist/bundle.mjs";
+const NPM_PKG_NAME: &str = "@vlabo/cspell-lsp";
+const LS_BIN_PATH: &str = "node_modules/@vlabo/cspell-lsp/dist/cspell-lsp.js";
 
 #[derive(Default)]
 struct CSpellExtension {
@@ -77,8 +77,6 @@ impl zed::Extension for CSpellExtension {
                     .to_string_lossy()
                     .to_string(),
                 "--stdio".to_string(),
-                "--dictionary".to_string(),
-                "~/.cspell-custom-words.txt".to_string(),
             ],
             env: Default::default(),
         })


### PR DESCRIPTION
Switch to the scoped `@vlabo/cspell-lsp` package and update the binary path. Remove hardcoded dictionary arguments for improved flexibility.

This allows to use custom dictionaries from the cspell config file.