### PR TITLE
Add 'Typst' to supported languages in extension.toml

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -83,6 +83,7 @@ languages = [
   "TOML",
   "TSX",
   "TypeScript",
+  "Typst",
   "Uiua",
   "Vue",
   "Vue.js",


### PR DESCRIPTION
Typst is a popular markup language, meant to be a latex replacement.