### PR TITLE
Add Helm, Make, ini language types

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -44,6 +44,7 @@ languages = [
   "HTML",
   "Hy",
   "Idris",
+  "ini",
   "Java",
   "JavaScript",
   "JSON",

--- a/extension.toml
+++ b/extension.toml
@@ -53,6 +53,7 @@ languages = [
   "LaTeX",
   "Lua",
   "Luau",
+  "Make",
   "Makefile",
   "Markdown",
   "Nim",

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "cspell"
 name = "CSpell"
 description = "CSpell Language Server for Zed editor"
-version = "0.0.6"
+version = "0.0.7"
 schema_version = 1
 authors = ["mantou132 <709922234@qq.com>"]
 repository = "https://github.com/mantou132/zed-cspell"
@@ -40,6 +40,7 @@ languages = [
   "Groovy",
   "Haskell",
   "HEEX",
+  "Helm",
   "HTML",
   "Hy",
   "Idris",


### PR DESCRIPTION
## Description

This PR adds the ability to use the [Helm](https://zed.dev/docs/languages/helm), [Make](https://zed.dev/extensions/make) and [ini](https://zed.dev/extensions/ini) language types.